### PR TITLE
index: make assumption what default basepath is

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ var DEFAULTS = {
     },
     packagePath: '../package',
     configsPath: './',
-    basepath: __dirname,
+    basepath: _resolve(_join(__dirname, '../../../')),
     dirname: 'config',
     globOptions: {
         matchPatterh: '**.js',


### PR DESCRIPTION
This closes #1 

We assume that the project layout is:

```
index.js <= require('simple-config-loader')
| - node_modules
    | - simple-config-loader
        | - lib
```
