### PR TITLE
make loading package optional

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,9 @@ ConfigLoader.prototype.init = function(opts){
     //We might want to remove unused props of
     //the package. For instance, the "readme"
     //portion might introduce errors by adding ${}
-    this.getPackage(data, this.packagePath);
+    if(this.packagePath){
+        this.getPackage(data, this.packagePath);
+    }
 
     data = this.loadConfigs(data);
 


### PR DESCRIPTION
We check to see if `packagePath` is set before attempting to load a **package.json** file.
This closes #10 